### PR TITLE
docs: update copyright name in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 TechStudent10
+Copyright (c) 2023 Proton Designer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Shouldn't the copyright name be Proton Designer (the organization) , instead of TechStudent10?
